### PR TITLE
Cache dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Change Log
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.1.1
+replace current cargo.rs with `cargo` crate and add dependencies cache.
+
+For details, see [#3](https://github.com/kngwyu/racer-nightly/pull/3) and [#4](https://github.com/kngwyu/racer-nightly/pull/4).
+
 ## 2.1.0
 First release of nightly
 Actually I didn't release it in crates.io, but I just bumped the version, because so many changes have been done.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "racer-nightly"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "cargo 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.31.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "racer-nightly"
-version = "2.1.0"
+version = "2.1.1"
 license = "MIT"
 description = "Code completion for Rust"
 authors = ["Phil Dawes <phil@phildawes.net>", "Yuji Kanagawa <yuji.kngw.80s.revive@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@
 - [ ] get definition of macros in other crates
 - [ ] complete `try_trait` support
 - [ ] completion based on trait bound
+- [ ] more precise research flag(e.g. `extern crate` in outer crates is not a module)

--- a/src/racer/ast.rs
+++ b/src/racer/ast.rs
@@ -1,7 +1,7 @@
 use core::{self, Match, MatchType, Point, Scope, Session, SessionExt, SourceByteRange, Ty};
-use typeinf;
 use nameres::{self, resolve_path_with_str};
 use scopes;
+use typeinf;
 
 use std::path::Path;
 use std::rc::Rc;
@@ -10,11 +10,11 @@ use rustc_errors::Handler;
 use rustc_errors::emitter::ColorConfig;
 use syntax::ast::{self, ExprKind, FunctionRetTy, GenericParam, Generics, ItemKind, LitKind,
                   PatKind, TyKind, TyParamBound, TyParamBounds, UseTree, UseTreeKind};
-use syntax::{self, codemap, visit};
 use syntax::parse::parser::Parser;
 use syntax::parse::{self, ParseSess};
 use syntax::print::pprust;
-use syntax_pos::{FileName, Span};
+use syntax::{self, visit, codemap::{self, Span}};
+use syntax_pos::FileName;
 
 // From syntax/util/parser_testing.rs
 pub fn string_to_parser<'a>(ps: &'a ParseSess, source_str: String) -> Parser<'a> {
@@ -323,15 +323,9 @@ fn destructure_pattern_to_ty(
                                 path_to_match(ty, session)
                             }
                         })
-                            .and_then(|ty| {
-                                destructure_pattern_to_ty(
-                                    &child.node.pat,
-                                    point,
-                                    &ty,
-                                    scope,
-                                    session,
-                                )
-                            });
+                        .and_then(|ty| {
+                            destructure_pattern_to_ty(&child.node.pat, point, &ty, scope, session)
+                        });
                         break;
                     }
                 }
@@ -535,10 +529,10 @@ fn find_type_match(path: &core::Path, fpath: &Path, pos: Point, session: &Sessio
         core::Namespace::Type,
         session,
     ).nth(0)
-        .and_then(|m| match m.mtype {
-            MatchType::Type => get_type_of_typedef(m, session, fpath),
-            _ => Some(m),
-        });
+    .and_then(|m| match m.mtype {
+        MatchType::Type => get_type_of_typedef(m, session, fpath),
+        _ => Some(m),
+    });
 
     res.and_then(|mut m| {
         // add generic types to match (if any)

--- a/src/racer/fileres.rs
+++ b/src/racer/fileres.rs
@@ -1,18 +1,21 @@
-use cargo::Config;
-use cargo::core::{TargetKind, Workspace, registry::PackageRegistry};
+use cargo::core::{TargetKind, Workspace};
 use cargo::ops::{resolve_ws_precisely, Packages};
 use cargo::util::important_paths::find_project_manifest;
+use cargo::Config;
 use core::Session;
 use nameres::RUST_SRC_PATH;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 /// get crate file from current path & crate name
 pub fn get_crate_file(name: &str, from_path: &Path, session: &Session) -> Option<PathBuf> {
     debug!("get_crate_file {}, {:?}", name, from_path);
 
-    if let Some(path) = get_outer_crates(name, from_path) {
+    if let Some(path) = get_outer_crates(name, from_path, session) {
         debug!("get_outer_crates returned {:?} for {}", path, name);
         return Some(path);
+    } else {
+        warn!("get_outer_crates returned None");
     }
 
     let srcpath = &*RUST_SRC_PATH;
@@ -54,7 +57,7 @@ pub fn get_module_file(name: &str, parentdir: &Path, session: &Session) -> Optio
 }
 
 /// try to get outer crates
-fn get_outer_crates(libname: &str, from_path: &Path) -> Option<PathBuf> {
+fn get_outer_crates(libname: &str, from_path: &Path, session: &Session) -> Option<PathBuf> {
     macro_rules! cargo_res {
         ($r:expr) => {
             match $r {
@@ -70,15 +73,53 @@ fn get_outer_crates(libname: &str, from_path: &Path) -> Option<PathBuf> {
         "[get_outer_crates] lib name: {:?}, from_path: {:?}",
         libname, from_path
     );
+    let libname_hyphened = {
+        let tmp_str = libname.to_owned();
+        tmp_str.replace("_", "-")
+    };
     let manifest = cargo_res!(find_project_manifest(from_path, "Cargo.toml"));
-    let config = cargo_res!(Config::default());
-    let ws = cargo_res!(Workspace::new(&manifest, &config));
-    let pkg = ws.current_opt()?;
-    for dep in pkg.dependencies() {}
-    let mut registry = cargo_res!(PackageRegistry::new(ws.config()));
-    for (url, patches) in ws.root_patch() {
-        cargo_res!(registry.patch(url, patches));
+    if let Some(deps_info) = session.deps(&manifest) {
+        debug!("[get_outer_crates] cache exists");
+        if let Some(p) = deps_info.get(libname) {
+            Some(p)
+        } else if let Some(p) = deps_info.get(&libname_hyphened) {
+            Some(p)
+        } else {
+            None
+        }
+    } else {
+        debug!("[get_outer_crates] cache doesn't exist");
+        let config = cargo_res!(Config::default());
+        let ws = cargo_res!(Workspace::new(&manifest, &config));
+        let pkg_cur = ws.current_opt()?;
+        let first_deps: HashSet<_> = pkg_cur.dependencies().iter().map(|d| d.name()).collect();
+        let specs = cargo_res!(Packages::All.into_package_id_specs(&ws));
+        let (packages, _) = cargo_res!(resolve_ws_precisely(&ws, None, &[], false, false, &specs));
+        let mut deps_map = HashMap::new();
+        let mut res = None;
+        for package_id in packages.package_ids() {
+            let pkg = cargo_res!(packages.get(package_id));
+            if !first_deps.contains(pkg.name()) {
+                continue;
+            }
+            let targets = pkg.manifest().targets();
+            let lib_target = targets.into_iter().find(|target| {
+                if let TargetKind::Lib(_) = target.kind() {
+                    true
+                } else {
+                    false
+                }
+            });
+            if let Some(target) = lib_target {
+                let name = target.name();
+                let src_path = target.src_path().to_owned();
+                if name == libname || name == libname_hyphened {
+                    res = Some(src_path.clone());
+                }
+                deps_map.insert(name.to_owned(), src_path);
+            }
+        }
+        session.cache_deps(manifest, deps_map);
+        res
     }
-    warn!("[get_outer_crates] failed to find package");
-    None
 }

--- a/src/racer/lib.rs
+++ b/src/racer/lib.rs
@@ -15,23 +15,23 @@ extern crate syntax_pos;
 #[macro_use]
 mod testutils;
 
-mod core;
-mod scopes;
 mod ast;
-mod typeinf;
-mod nameres;
-mod util;
-mod codeiter;
 mod codecleaner;
-mod matchers;
-mod snippets;
+mod codeiter;
+mod core;
 mod fileres;
+mod matchers;
+mod nameres;
+mod scopes;
+mod snippets;
+mod typeinf;
+mod util;
 
+pub use core::{Coordinate, FileCache, FileLoader, Location, Point, Session, SourceByteRange};
+pub use core::{Match, MatchType, PathSearch};
 pub use core::{complete_from_file, complete_fully_qualified_name, find_definition, to_coords,
                to_point};
 pub use snippets::snippet_for_match;
-pub use core::{Match, MatchType, PathSearch};
-pub use core::{Coordinate, FileCache, FileLoader, Location, Point, Session, SourceByteRange};
 pub use util::expand_ident;
 
 pub use util::{get_rust_src_path, RustSrcPathError};

--- a/test_project/src/lib.rs
+++ b/test_project/src/lib.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod tests {
     #[test]
-    fn it_works() {
-    }
+    fn it_works() {}
 }

--- a/test_project/test_fixtures/Cargo.toml
+++ b/test_project/test_fixtures/Cargo.toml
@@ -6,3 +6,6 @@ authors = ["jaxx"]
 [lib]
 name = "fixtures"
 path = "src/lib.rs"
+
+[dependencies]
+test-crate2 = { path = "../test-crate2"}

--- a/test_project/test_fixtures/src/lib.rs
+++ b/test_project/test_fixtures/src/lib.rs
@@ -14,5 +14,12 @@
 //! ## Notes:
 //! - We should check racer can parse rust doc style comments
 //! - and some comments...
+
+extern crate test_crate2;
+
+#[path = "submod/bar.rs"]
+pub mod bar;
+
 pub mod foo;
-#[path = "submod/bar.rs"] pub mod bar;
+
+pub use test_crate2::useless_func;

--- a/test_project/test_fixtures/src/lib.rs
+++ b/test_project/test_fixtures/src/lib.rs
@@ -4,8 +4,8 @@
 //! Basic Usage.
 //!
 //! ```
-//! extern crate test_fixtures;
-//! use test_fixtures::foo;
+//! extern crate fixtures;
+//! use fixtures::foo;
 //! fn main {
 //!     println!("Racer")
 //! }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -3994,8 +3994,8 @@ fn find_crate_doc() {
 Basic Usage.
 
 ```
-extern crate test_fixtures;
-use test_fixtures::foo;
+extern crate fixtures;
+use fixtures::foo;
 fn main {
     println!("Racer")
 }

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1362,8 +1362,8 @@ fn follows_use_local_package() {
 
     let dir = setup_test_project();
     let srcdir = dir.nested_dir("src");
-    let got = get_one_completion(src, Some(srcdir));
-    assert_eq!(got.matchstr, "foo");
+    let got = get_all_completions(src, Some(srcdir));
+    assert!(got.iter().any(|ma| ma.matchstr == "foo"));
 }
 
 #[test]

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -1380,6 +1380,20 @@ fn follows_use_local_package_hyphend() {
     assert_eq!(got.matchstr, "useless_func");
 }
 
+// test for re-export
+#[test]
+fn follows_use_reexport() {
+    let src = "
+    extern crate fixtures;
+
+    use fixtures::use~;
+    ";
+    let dir = setup_test_project();
+    let srcdir = dir.nested_dir("src");
+    let got = get_only_completion(src, Some(srcdir));
+    assert_eq!(got.matchstr, "useless_func");
+}
+
 #[test]
 fn completes_struct_field_via_assignment() {
     let src = "


### PR DESCRIPTION
I modified to cache dependencies when finding outer crates.
~Though it's difficult to bench~, it seems to work properly in my local
'using' test(by emacs)
(Edited 4/7: This change need benchmark).
In addition, tests for re-exported crates and additional comments are needed.