### PR TITLE
method completion for closure args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,9 +737,9 @@ dependencies = [
  "env_logger 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_cratesio_shim"
-version = "89.0.0"
+version = "100.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-rustc_data_structures"
-version = "89.0.0"
+version = "100.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -813,20 +813,20 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "stable_deref_trait 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-rustc_errors"
-version = "89.0.0"
+version = "100.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -834,32 +834,32 @@ dependencies = [
 
 [[package]]
 name = "rustc-ap-serialize"
-version = "89.0.0"
+version = "100.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rustc-ap-syntax"
-version = "89.0.0"
+version = "100.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_cratesio_shim 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-rustc_errors 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-syntax_pos 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_cratesio_shim 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_errors 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-syntax_pos 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rustc-ap-syntax_pos"
-version = "89.0.0"
+version = "100.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-rustc_data_structures 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-ap-serialize 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1324,12 +1324,12 @@ dependencies = [
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
 "checksum regex-syntax 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2550876c31dc914696a6c2e01cbce8afba79a93c8ae979d2fe051c0230b3756"
 "checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
-"checksum rustc-ap-rustc_cratesio_shim 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a78bda69468474cd71e758ae38e6941e85f836024621134f302d1186c0e8dc24"
-"checksum rustc-ap-rustc_data_structures 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7f5888f20a213def17eae391dc1ccc35d45bdafb55a50f6ede64366309928adf"
-"checksum rustc-ap-rustc_errors 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec73f8e6d50d8354f8c73a8933c7247c1da0c83c165e43a6453586ece2f1fc44"
-"checksum rustc-ap-serialize 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc4c01e2e699c5218cd6a4259d0b361f260300c74b48389a968868e902c7dbc5"
-"checksum rustc-ap-syntax 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb3954b2f98d9c05ea0cbe8d4d72352552ed20f22de7083c04576cdd6f8b432f"
-"checksum rustc-ap-syntax_pos 89.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6efc72a1191597fbaf780158b2bad3922820557606607a26d8088852fc416f5"
+"checksum rustc-ap-rustc_cratesio_shim 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "08d9fb826850cb282e22f6361776d0aa47829e0e5e111a7a75fe000696e0bef9"
+"checksum rustc-ap-rustc_data_structures 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c5e69f3754bd020590db384445624a71a450669eaa62228cb6f20b03408ac201"
+"checksum rustc-ap-rustc_errors 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b18e3b715446b71e4a3b9fc7bac9cc133c257e9725dc1ed791ffc0b3b4b018d6"
+"checksum rustc-ap-serialize 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf26e5b69478698716f77cb3cfcc643f1ae8f3e8b4cd09aa17c9be1fc61352ed"
+"checksum rustc-ap-syntax 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b1c2ec73d199105dd685e5770b79de18f89d4a4ba6d815d7022788eee4fb856"
+"checksum rustc-ap-syntax_pos 100.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6f8abaa0e8bfdd923dbd8499171082709d9267551e3162ae53b7c4ccf285c2e"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
 "checksum same-file 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cfb6eded0b06a0b512c8ddbcf04089138c9b4362c2f696f3c3d76039d68f3637"
 "checksum schannel 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fbaffce35eb61c5b00846e73128b0cd62717e7c0ec46abbec132370d013975b4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ env_logger = "0.5"
 cargo = "0.26"
 clap = "2.31"
 lazy_static = "1.0"
-rustc-ap-rustc_errors = "89.0.0"
-rustc-ap-syntax = "89.0.0"
-rustc-ap-syntax_pos = "89.0.0"
+rustc-ap-rustc_errors = "100.0.0"
+rustc-ap-syntax = "100.0.0"
+rustc-ap-syntax_pos = "100.0.0"
 
 [dependencies.clippy]
 version = "0.0.192"

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -117,8 +117,7 @@ where
                     }
                     _ => {}
                 }
-
-                if enddelim == b && bracelevel == 0 && parenlevel == 0 {
+                if enddelim == b && bracelevel == 0 && parenlevel <= 0 {
                     self.pos = pos;
                     return Some((start, pos));
                 }

--- a/src/racer/codeiter.rs
+++ b/src/racer/codeiter.rs
@@ -23,6 +23,7 @@ where
         let src_bytes = self.src.as_bytes();
         let mut enddelim = b';';
         let mut bracelevel = 0isize;
+        let mut bracketlevel = 0isize;
         let mut parenlevel = 0isize;
         let mut start = self.pos;
         let mut pos = self.pos;
@@ -83,6 +84,12 @@ where
                     b')' => {
                         parenlevel -= 1;
                     }
+                    b'[' => {
+                        bracketlevel += 1;
+                    }
+                    b']' => {
+                        bracketlevel -= 1;
+                    }
                     b'{' => {
                         // if we are top level and stmt is not a 'use' or 'let' then
                         // closebrace finishes the stmt
@@ -117,7 +124,7 @@ where
                     }
                     _ => {}
                 }
-                if enddelim == b && bracelevel == 0 && parenlevel <= 0 {
+                if enddelim == b && bracelevel == 0 && parenlevel <= 0 && bracketlevel == 0 {
                     self.pos = pos;
                     return Some((start, pos));
                 }
@@ -170,6 +177,22 @@ mod test {
             pos: 0,
             end: 0,
         }.fuse()
+    }
+
+    #[test]
+    fn iterates_array_stmts() {
+        let src = rejustify(
+            "
+            let a: [i32; 2] = [1, 2];
+            let b = [[0], [1], [2]];
+            let c = ([1, 2, 3])[1];
+        ",
+        );
+
+        let mut it = iter_stmts(src.as_ref());
+        assert_eq!("let a: [i32; 2] = [1, 2];", slice(&src, it.next().unwrap()));
+        assert_eq!("let b = [[0], [1], [2]];", slice(&src, it.next().unwrap()));
+        assert_eq!("let c = ([1, 2, 3])[1];", slice(&src, it.next().unwrap()));
     }
 
     #[test]

--- a/src/racer/nameres.rs
+++ b/src/racer/nameres.rs
@@ -1205,14 +1205,11 @@ fn search_closure_args(
         if txt_matches(search_type, searchstr, pipe_scope) {
             // Add a fake body for parsing
             let closure_def = String::from(pipe_scope) + "{}";
-
             let coords = ast::parse_fn_args(closure_def.clone());
 
             let mut out: Vec<Match> = Vec::new();
-
             for (start, end) in coords {
                 let s = &closure_def[start..end];
-
                 if symbol_matches(search_type, searchstr, s) {
                     let m = Match {
                         matchstr: s.to_owned(),

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -286,12 +286,16 @@ pub fn get_struct_field_type(
     session: &Session,
 ) -> Option<core::Ty> {
     assert!(structmatch.mtype == core::MatchType::Struct);
-
+    debug!("[get_struct_filed_type]{}, {:?}", fieldname, structmatch);
     let src = session.load_file(&structmatch.filepath);
 
     let opoint = scopes::expect_stmt_start(src.as_src(), structmatch.point);
     let structsrc = scopes::end_of_next_scope(&src[opoint..]);
-
+    let structsrc = if structsrc == "" {
+        (*get_first_stmt(src.as_src().from(opoint))).to_owned()
+    } else {
+        structsrc.to_owned()
+    };
     let fields = ast::parse_struct_fields(structsrc.to_owned(), Scope::from_match(structmatch));
     for (field, _, ty) in fields.into_iter() {
         if fieldname == field {

--- a/src/racer/typeinf.rs
+++ b/src/racer/typeinf.rs
@@ -137,25 +137,53 @@ pub fn get_type_of_self(
 }
 
 fn get_type_of_fnarg(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {
+    fn is_closure(src: &str) -> Option<bool> {
+        let s = src.matches(|c| c == '{' || c == '|').nth(0)?;
+        Some(s == "|")
+    }
+    fn find_start_of_closure_body(src: &str) -> Option<Point> {
+        let mut cnt = 0;
+        for (i, c) in src.chars().enumerate() {
+            if c == '|' {
+                cnt += 1;
+            }
+            if cnt == 2 {
+                return Some(i + 1);
+            }
+        }
+        warn!(
+            "[get_type_of_fnarg] start of closure body not found!: {}",
+            src
+        );
+        None
+    }
+
     if m.matchstr == "self" {
         return get_type_of_self_arg(m, msrc, session);
     }
     let stmtstart = scopes::expect_stmt_start(msrc, m.point);
     let block = msrc.from(stmtstart);
-    if let Some((start, end)) = block.iter_stmts().next() {
-        let blob = &msrc[(stmtstart + start)..(stmtstart + end)];
+    let (start, end) = block.iter_stmts().nth(0)?;
+    let blob = &msrc[(stmtstart + start)..(stmtstart + end)];
+    let is_closure = is_closure(blob)?;
+    if is_closure {
+        let start_of_body = find_start_of_closure_body(blob)?;
+        let s = format!("{}{{}}", &blob[..start_of_body]);
+        let argpos = m.point - (stmtstart + start);
+        let offset = (stmtstart + start) as i32;
+        ast::parse_fn_arg_type(s, argpos, Scope::from_match(m), session, offset)
+    } else {
         // wrap in "impl blah { }" so that methods get parsed correctly too
-        let mut s = String::new();
         let start_blah = "impl blah {";
-        s.push_str(start_blah);
-        let impl_header_len = s.len();
-        s.push_str(&blob[..(find_start_of_function_body(blob) + 1)]);
-        s.push_str("}}");
-        let argpos = m.point - (stmtstart + start) + impl_header_len;
+        let s = format!(
+            "{}{}}}}}",
+            start_blah,
+            &blob[..(find_start_of_function_body(blob) + 1)]
+        );
+        let argpos = m.point - (stmtstart + start) + start_blah.len();
         let offset = (stmtstart + start) as i32 - start_blah.len() as i32;
-        return ast::parse_fn_arg_type(s, argpos, Scope::from_match(m), session, offset);
+        ast::parse_fn_arg_type(s, argpos, Scope::from_match(m), session, offset)
     }
-    None
 }
 
 fn get_type_of_let_expr(m: &Match, msrc: Src, session: &Session) -> Option<core::Ty> {

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4022,6 +4022,7 @@ fn completes_methods_for_global_enum() {
     assert_eq!(get_only_completion(src, None).matchstr, "unwrap_or_default");
 }
 
+// For issue 785
 #[test]
 fn completes_methods_for_local_enum() {
     let src = "
@@ -4037,6 +4038,23 @@ fn completes_methods_for_local_enum() {
     }
     ";
     assert_eq!(get_only_completion(src, None).matchstr, "method");
+}
+
+#[test]
+fn completes_methods_for_closure_arg() {
+    let src = r"
+        fn main() {
+            let mut v = Vec::new();
+            v.push(3);
+            let s = Some(v);
+            let x = s.map(|v: Vec<i32>| v.appen~);
+        }
+    ";
+    assert!(
+        get_all_completions(src, None)
+            .into_iter()
+            .any(|ma| ma.matchstr == "append")
+    );
 }
 
 // issue 706

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4057,6 +4057,22 @@ fn completes_methods_for_closure_arg() {
     );
 }
 
+#[test]
+fn completes_methods_for_tuple_struct() {
+    let src = r"
+        fn main() {
+            struct A(i32, Vec<i32>);
+            let mut a = A(0, vec![3, 4]);
+            a.1.appen~
+        }
+    ";
+    assert!(
+        get_all_completions(src, None)
+            .into_iter()
+            .any(|ma| ma.matchstr == "append")
+    );
+}
+
 // issue 706
 mod trait_bounds {
     use super::*;


### PR DESCRIPTION
This commit enables method completion for closure args, like
```rust
let v = vec![3, 4];
let s = Some(v).map(|v: Vec<i32>| v.clone());
```

Now type annotation is needed, but I'm going to implement type inference in the future, when I implement method completion based on trait bounds.

Edited: this PR includes update of `rustc-ap-syntax`