### PR TITLE
Enable code completion based on trait bounds for function args

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@
 - [x] rewrite get_crate_file using `cargo` crate
   - [x] cache `src_path`s of outer crates
 - [x] method completion for closure args
+- [ ] completion based on trait bound
+  - [x] for function args
 - [ ] get definition of macros in other crates
 - [ ] complete `try_trait` support
-- [ ] completion based on trait bound
 - [ ] more precise research flag(e.g. `extern crate` in outer crates is not a module)
 
 ## install

--- a/tests/system.rs
+++ b/tests/system.rs
@@ -4077,7 +4077,6 @@ fn completes_methods_for_tuple_struct() {
 mod trait_bounds {
     use super::*;
     #[test]
-    #[ignore]
     fn completes_methods_for_fnarg_by_trait_bounds() {
         let src = "
         fn main() {
@@ -4093,7 +4092,6 @@ mod trait_bounds {
     }
 
     #[test]
-    #[ignore]
     fn completes_external_methods_for_fnarg_by_trait_bounds() {
         let src = "
         fn main() {
@@ -4110,7 +4108,6 @@ mod trait_bounds {
     }
 
     #[test]
-    #[ignore]
     fn completes_inherited_methods_for_fnarg_by_trait_bounds() {
         let src = "
         fn main() {
@@ -4130,7 +4127,6 @@ mod trait_bounds {
 
     // test for checking racer don't cause INF loop
     #[test]
-    #[ignore]
     fn completes_inherited_methods_with_cycle() {
         let src = "
         fn main() {


### PR DESCRIPTION
It's rebump of https://github.com/racer-rust/racer/pull/828.
As a first aid to libsyntax's change, I turned off this feature, but now I modified codes in accordance with libsyntax. Those changes are very straight forward.
In addition, this commit includes removal of unused codes and some refactoring of related codes.